### PR TITLE
Instructions for accessing shared files on S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Each row in this file corresponds to a library and contains the following column
 | `loom_file`       | loom file name in the format `tissue_group/project_name/bundle_uuid/filename` |
 
 3. `hca-processed-libraries.tsv`: This file contains the list of libraries from each project that are being used for testing data integration. 
-This file is used as input to the script, `scripts/00-convert-loom.R`, used for converting loom to `SingleCellExperiment` objects and saving those objects to S3. 
+This file is used as input to the script, `scripts/00-obtain-sce.R`, used for converting loom to `SingleCellExperiment` objects and saving those objects to S3. 
 
 ## Shared data files 
 
@@ -73,7 +73,7 @@ The following data can be found in the above S3 bucket within the `human_cell_at
 - The `loom` folder contains the original loom files downloaded from the Human Cell Atlas data portal for each test dataset. 
 Here loom files are nested by `tissue_group`, `project_name`, and `bundle_uuid`. 
 - The `sce` folder contains the unfiltered `SingleCellExperiment` objects saved as RDS files.
-These `SingleCellExperiment` objects have been converted from the loom files using the `00-loom-convert.R` script in the `scripts` directory in this repo.
+These `SingleCellExperiment` objects have been converted from the loom files using the `00-obtain-sce.R` script in the `scripts` directory in this repo.
 Here RDS files are nested by `tissue_group` and `project_name`.
 
 A separate `reference-files` folder contains any reference files needed for processing dataset, such as the gtf file needed to generate the mitochondrial gene list found in the `reference-files` folder in the repository. 


### PR DESCRIPTION
Closes #10. 

This PR adds a section to the main readme file discussing which data files are centrally stored and how to access these files. I included the S3 bucket that the files are located in and a short description on whats inside each of the folders. In order to access these files using the scripts that are in the repo you need to have AWS CLI installed, so I included a link to the [instructions that we have written up in `alsf-scpca`](https://github.com/AlexsLemonade/alsf-scpca#aws). Reviewers please let me know if you think we should expand on these instructions at all. 

I also included a short section on how to access the SCE objects that are stored on S3 and what script to use. Note that the option that I mentioned is added in #26, but I thought it was worth mentioning how to grab the files that you need for analysis. 

I also anticipate there to be some additional instructions after we process the SCE objects and store the outputs on S3 for input to data integration, but wanted to get these started and we can modify later. 