### PR TITLE
Document scripts directory

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -70,13 +70,13 @@ This file is the default file that is used in running `01-run-downstream-analyse
 **Note:** You must have available in your path R (v4.1.2),  [Snakemake](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html#installation-via-conda-mamba) and [`pandoc`](https://pandoc.org/installing.html#macos). 
 `pandoc` must be version 1.12.3 or higher, which can be checked using the `pandoc -v` command.
 
-```R
+```sh
 bash 01-run-downstream-analyses.sh --downstream_repo <path to location of scpca-downstream-repo>
 ```
 
 If desired, an S3 bucket link can be provided to ensure that the results from `scpca-downstream-analyses` are copied to S3 for other Data Lab staff members to use. 
 
-```R 
+```sh 
 bash 01-run-downstream-analyses.sh \
   --downstream_repo <path to location of scpca-downstream-repo> \
   --s3_bucket "s3://sc-data-integration/human_cell_atlas_results"
@@ -85,6 +85,11 @@ bash 01-run-downstream-analyses.sh \
 By default, filtering of empty droplets will not be repeated if filtered `SingleCellExperiment` objects are already present locally. 
 To overwrite existing filtered files, use `--repeat_filtering yes` at the command line. 
 
+```sh
+bash 01-run-downstream-analyses.sh \
+  --downstream_repo <path to location of scpca-downstream-repo> \
+  --repeat_filtering yes
+```
 
 ### Generating the mitochondrial gene list 
 


### PR DESCRIPTION
Closes #28. 
⚠️ stacked on #19 

Here I added a readme file specifically for the scripts directory. I included a section for each of the scripts that we currently have. I chose to stack this on #19 because I wanted to include instructions for running the bash script in that PR as well. I tried to include most of the different options that one would want to run, but let me know if things are either confusing or appear to be missing. 

I also decided to put the mito list generation in a subheading under running the downstream analyses script because generating the mito file is necessary for the input to the downstream analyses script. Please let me know if this organization is confusing in anyway. 