### PR TITLE
Remove absolute path requirement from run-downstream-analysis script 

### DIFF
--- a/scripts/01-run-downstream-analyses.sh
+++ b/scripts/01-run-downstream-analyses.sh
@@ -91,7 +91,6 @@ fi
 snakemake --cores $cores \
   -s $downstream_repo/Snakefile \
   --configfile $downstream_repo/config.yaml \
-  --use-conda \
   --config results_dir=$results_dir \
   project_metadata=$downstream_metadata_file \
   mito_file=$mito_file


### PR DESCRIPTION
This PR does a couple of things to handle paths a bit more as I would expect by a bash script that takes arguments. In particular, it removes _most_ of the `cd` calls (or rather, quickly moves back to the calling directory), so any paths that are specified, including the path to the downstream analysis repo can be specified as relative paths. 

I think there may have been some unintended errors if any relative paths had been specified, in particular because the `results_dir` was used after a directory change to `project_dir`

This version also adds the `--config_file` to argument to explicitly use the configfile that is part of the downstream analysis repo, which gets around one of the changes that I made in https://github.com/AlexsLemonade/scpca-downstream-analyses/pull/166. I don't currently check for existence of that file, so let me know if you think I should add that. 

(Also a bunch of trailing spaces removed... sorry for the mess!)