### PR TITLE
Fix bugs in `combine_sce_objects()` function

### DIFF
--- a/scripts/utils/integration-helpers.R
+++ b/scripts/utils/integration-helpers.R
@@ -78,11 +78,14 @@ combine_sce_objects <- function(sce_list = list(),
     # Subset to shared genes
     sce_list[[i]] <- sce_list[[i]][shared_genes,]
       
-    # Add relevant sample IDs to rowData column names
+    # Add relevant library ID to rowData column names
     colnames(rowData(sce_list[[i]])) <- paste0(colnames(rowData(sce_list[[i]])), "-", library_name)
     
-    # Add relevant sample IDs to colData row names
+    # Add relevant library ID to colData row names
     colnames(sce_list[[i]]) <- paste0(colnames(sce_list[[i]]), "-", library_name)
+    
+    # Add relevant library ID to metadata names
+    names(metadata(sce_list[[i]])) <- paste0(names(metadata(sce_list[[i]])), "-", library_name)
     
     # Add colData column to track this batch
     sce_list[[i]]$batch <- library_name


### PR DESCRIPTION
Closes #58 

This PR addresses two problems I found with `combine_sce_objects()` - 

- One is documented in issue #58. The metadata names are effectively duplicated after merging (or more, if >2 sce's!), so we should be handling metadata names as we handle rowData and colData names by tacking on the `-libraryID` to the end of each name. That feature has been added to the function.
- I found another bug while beginning work on #37 that I have also fixed here. The bug was in the same general location of the code, where the library ID was being added onto column names. The variable being used to assign, `library_ids` was never properly defined in this script so it was just inheriting whatever recent definition may have been run. As a consequence, indexing was bonkers and all library IDs were wrong. On my machine, they were  _all_ either `SRX7129196` or `SRX7129192`, the first two library IDs which appear in our metadata, which corresponds to how `library_ids` had been incidentally defined. 

We should therefore all re-run this aspect of the pipeline locally to ensure result files are properly named before proceeding to next steps.