### PR TITLE
Remove param quotes

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -121,7 +121,7 @@ rule integrate_seurat:
           --output_sce_file "{output}" \
           --method seurat \
           --seurat_reduction_method {wildcards.method} \
-          --num_genes "{params.num_genes}" \
+          --num_genes {params.num_genes} \
           --corrected_only
         """
 


### PR DESCRIPTION
This PR removes some quotes from the Snakefile that I shouldn't be there for an `int` argument! The quotes don't break the pipeline (so far!), but still let's remove the quotes.