### PR TITLE
Use conda for downstream analysis

### DIFF
--- a/scripts/01-run-downstream-analyses.sh
+++ b/scripts/01-run-downstream-analyses.sh
@@ -99,7 +99,7 @@ fi
 
 snakemake --cores $cores \
   --use-conda \
-  --forceall \
+  --forceall --rerun-incomplete \
   --config results_dir=$results_dir \
   project_metadata=$downstream_metadata_file \
   mito_file=$mito_file


### PR DESCRIPTION
Closes #93

This PR adds using conda as the expected way to run the downstream analysis repo. Because we were having trouble with paths, we short-circuit those by `cd`ing into the  downstream analysis directory and running the workflow there. As all relevant paths have already been set as absolute by earlier steps in the script (and earlier scripts), this should work as expected (and does in my testing).

In most cases, this will also automatically set up any conda environment for the downstream repo as required, but for Apple Silicon we will need an extra step to be sure we are using the Intel version of R, which is included here.