### PR TITLE
Fix fastmnn gene list bug

### DIFF
--- a/scripts/03a-integrate-sce.R
+++ b/scripts/03a-integrate-sce.R
@@ -237,7 +237,9 @@ if (integration_method == "fastmnn") {
   # Prepare `gene_list` argument
   if (opt$fastmnn_use_all_genes) {
     fastmnn_gene_list <- NULL
-  } 
+  } else {
+    fastmnn_gene_list <- metadata(merged_sce_obj)$variable_genes
+  }
 
   # Perform integration
   integrated_sce_obj <- integrate_fastMNN(


### PR DESCRIPTION
This PR fixes a bug that was introduced in #124 where lines setting the `fastmnn_gene_list` to be variable genes were accidentally deleted, lines 240-242 in `03a-integrate-sce.R` here: https://github.com/AlexsLemonade/sc-data-integration/pull/124/files#