### PR TITLE
Function to plot PCA regression

### DIFF
--- a/analysis_templates/01-single-group-integration-check-template.Rmd
+++ b/analysis_templates/01-single-group-integration-check-template.Rmd
@@ -282,8 +282,10 @@ pca_integrated <- calculate_pca_regression(integrated_sce,
 pca_df <- dplyr::bind_rows(pca_unintegrated, pca_integrated)
 ```
 
-```{r}
+```{r fig.height=8, fig.width=8}
 head(pca_df)
+
+plot_pca_regression(pca_df, seed = params$seed)
 ```
 
 ## Session Info


### PR DESCRIPTION
Closes #120 
**_:warning: Stacked on #128_**

This PR adds a plotting function for the PCA regression. Specifically, I use `cowplot::plot_grid()` to return two panels: violin/sina for batch variance, and violin/sina for scaled regression. I added the function to the template, and I updated that R chunk's output figure size to ensure it all fits legibly (needed since long y-axis label).

In addition, I pulled out some shared code that formats that integration method for plotting into its own function. This also affects `plot_batch_asw()`.