### PR TITLE
Fix how downsampling is grabbing batch labels

### DIFF
--- a/scripts/utils/integration-helpers.R
+++ b/scripts/utils/integration-helpers.R
@@ -439,10 +439,10 @@ downsample_pcs_for_metrics <- function(integrated_pcs, frac_cells, num_pcs) {
   downsampled_integrated_pcs <- integrated_pcs[downsampled_indices,1:num_pcs]
   
   # Obtain batch labels as integer values
-  downsampled_batch_labels <- stringr::str_replace_all(
+  downsampled_batch_labels <- stringr::word(
     rownames(downsampled_integrated_pcs),
-    "^[ACGT]+-",
-    ""
+    2,
+    sep = "-"
   ) %>%
     as.factor() %>%
     as.numeric()


### PR DESCRIPTION
In trying to render the sim reports I noticed that there was an issue with some of the plots and we were seeing all 0's showing complete mismatching of batch assignments even in the unintegrated data. I went back to investigate this and it was because in the downsampling function we were grabbing batch labels by removing the cell barcode. The problem is that with the sim data the cell barcode is `Cell123` rather than a typical cell barcode. Because we append the library ID to the cell barcode with `-`, I just altered the function to explicitly grab that library ID to create the batch labels instead and that did the trick! 