### PR TITLE
Add github action workflow for testing integration workflow

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           directory: '.'
           snakefile: 'Snakefile'
-          args: '--list --configfile config.yaml'
+          args: '--list'
           task: 'run'


### PR DESCRIPTION
After some discussion in slack about adding status checks, I went ahead and created a github action that will perform a dry run of the Snakefile upon pushing to a branch off main. I believe I set this up correctly but I'm not entirely sure... I used the [`Snakemake github action` docs as a guide](https://github.com/marketplace/actions/snakemake). 

In thinking about this though I'm not quite sure how `--dry-run` will behave without the input SCE files not present on github? 