### PR TITLE
Fix typo in error message

### DIFF
--- a/scripts/utils/integrate-seurat.R
+++ b/scripts/utils/integrate-seurat.R
@@ -89,7 +89,7 @@ integrate_seurat <- function(seurat_list,
   # check that reduction method is valid
   reduction_method <- tolower(reduction_method)
   if (!reduction_method %in% c("cca", "rpca")) {
-    stop("The `reduction_method` must be one of `cca` or `rpca` (case-insentitive).")
+    stop("The `reduction_method` must be one of `cca` or `rpca` (case insensitive).")
   }
   
   # find common variable features for integration


### PR DESCRIPTION
Noticed this because I had it pulled up as a reference during the training workshop.