### PR TITLE
Add parameter for merge order and integration order

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -46,6 +46,7 @@ rule merge_sces:
           --merged_sce_dir "{output}" \
           --num_hvg {config[num_hvg]} \
           --subset_hvg \
+          --seed {config[seed]} \
           {config[random_merge]} \
           &> {log}
         """

--- a/Snakefile
+++ b/Snakefile
@@ -41,7 +41,7 @@ rule merge_sces:
           --library_file "{input.processed_tsv}" \
           --add_celltype {config[add_celltype]} \
           --celltype_info "{config[celltype_file]}" \
-          --random_merge {config[random_merge]} \
+          {config[random_merge]} \
           --grouping_var {config[grouping_var]} \
           --groups_to_integrate "{config[groups_to_integrate]}" \
           --merged_sce_dir "{output}" \

--- a/Snakefile
+++ b/Snakefile
@@ -41,12 +41,12 @@ rule merge_sces:
           --library_file "{input.processed_tsv}" \
           --add_celltype {config[add_celltype]} \
           --celltype_info "{config[celltype_file]}" \
-          {config[random_merge]} \
           --grouping_var {config[grouping_var]} \
           --groups_to_integrate "{config[groups_to_integrate]}" \
           --merged_sce_dir "{output}" \
           --num_hvg {config[num_hvg]} \
           --subset_hvg \
+          {config[random_merge]} \
           &> {log}
         """
 

--- a/Snakefile
+++ b/Snakefile
@@ -90,6 +90,7 @@ rule integrate_fastmnn:
           --method fastMNN \
           --seed {config[seed]} \
           --corrected_only \
+          {config[fastmnn_auto_merge]} \
           &> {log}
         """
 

--- a/Snakefile
+++ b/Snakefile
@@ -41,6 +41,7 @@ rule merge_sces:
           --library_file "{input.processed_tsv}" \
           --add_celltype {config[add_celltype]} \
           --celltype_info "{config[celltype_file]}" \
+          --random_merge {config[random_merge]} \
           --grouping_var {config[grouping_var]} \
           --groups_to_integrate "{config[groups_to_integrate]}" \
           --merged_sce_dir "{output}" \

--- a/Snakefile
+++ b/Snakefile
@@ -35,6 +35,8 @@ rule merge_sces:
         directory(os.path.join(config["results_dir"], "merged_sce"))
     log:
         "logs/merge_sce.log"
+    params:
+        random_merge_flag = '--random_merge' if config['random_merge'] else ''
     shell:
         """
         Rscript scripts/02-prepare-merged-sce.R \
@@ -47,7 +49,7 @@ rule merge_sces:
           --num_hvg {config[num_hvg]} \
           --subset_hvg \
           --seed {config[seed]} \
-          {config[random_merge]} \
+          {params.random_merge_flag} \
           &> {log}
         """
 
@@ -83,6 +85,7 @@ rule integrate_fastmnn:
         "logs/{basedir}/{project}/integrate_fastmnn.log"
     params:
         merged_sce_file = "{project}_merged_sce.rds",
+        auto_merge_flag = '--fastmnn_auto_merge' if config['fastmnn_auto_merge'] else ''
     shell:
         """
         Rscript scripts/03a-integrate-sce.R \
@@ -91,7 +94,7 @@ rule integrate_fastmnn:
           --method fastMNN \
           --seed {config[seed]} \
           --corrected_only \
-          {config[fastmnn_auto_merge]} \
+          {params.auto_merge_flag} \
           &> {log}
         """
 

--- a/analysis_templates/01-single-group-integration-check-template.Rmd
+++ b/analysis_templates/01-single-group-integration-check-template.Rmd
@@ -23,6 +23,7 @@ output:
     toc_depth: 3
     toc_float: true
     number_sections: true
+    code_folding: hide
 ---
 
 ## Set Up
@@ -319,6 +320,27 @@ if (celltypes_present) {
     count_groups("celltype_plot_names"),
     "celltype_plot_names"
   )
+}
+```
+
+
+## Merging and integration order
+
+```{r, results='asis'}
+# grab merge order from merged sce object
+merge_order <- metadata(sce_list[["unintegrated"]])$merge_order
+
+warning(glue::glue("The libraries in this dataset were merged in the following order: {merge_order}"))
+```
+
+
+```{r, results='asis'}
+if("fastmnn" %in% integration_methods){
+  # grab fastmnn auto merge from fastmnn object
+  fastmnn_integration_order <- metadata(sce_list[["fastmnn"]])$fastmnn_auto_merge
+  
+  warning(glue::glue("The libraries in this dataset were integrated in the following order when integrated with fastmnn: {fastmnn_integration_order}"))
+  
 }
 ```
 

--- a/analysis_templates/01-single-group-integration-check-template.Rmd
+++ b/analysis_templates/01-single-group-integration-check-template.Rmd
@@ -70,6 +70,11 @@ knitr::knit_hooks$set(
      paste('\n\n<div class="alert alert-warning">',
            gsub('##', '\n', gsub('^##\ Warning:', '**Warning**', x)),
            '</div>', sep = '\n')
+   }, 
+   message = function(x, options) {
+     paste('\n\n<div class="alert alert-info">',
+           gsub('##', '\n', x),
+           '</div>', sep = '\n')
    }
 )
 
@@ -330,7 +335,7 @@ if (celltypes_present) {
 # grab merge order from merged sce object
 merge_order <- metadata(sce_list[["unintegrated"]])$merge_order
 
-warning(glue::glue("The libraries in this dataset were merged in the following order: {merge_order}"))
+message(glue::glue("The libraries in this dataset were merged in the following order: {merge_order}"))
 ```
 
 
@@ -339,7 +344,7 @@ if("fastmnn" %in% integration_methods){
   # grab fastmnn auto merge from fastmnn object
   fastmnn_integration_order <- metadata(sce_list[["fastmnn"]])$fastmnn_auto_merge
   
-  warning(glue::glue("The libraries in this dataset were integrated in the following order when integrated with fastmnn: {fastmnn_integration_order}"))
+  message(glue::glue("The libraries in this dataset were integrated in the following order when integrated with fastmnn: {fastmnn_integration_order}"))
   
 }
 ```

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,5 +25,6 @@ num_latent: 20
 groups_to_integrate: "All"
 
 # randomize merge order prior to integration
-random_merge: '' # --random_merge
-fastmnn_auto_merge: '' # --fastmnn_auto_merge
+random_merge: False
+# automatically determine integration order for fastmnn
+fastmnn_auto_merge: False

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,5 +24,5 @@ num_latent: 20
 # to run a subset of projects use a python-formatted list '["1M_Immune_Cells", "HumanBrainSubstantiaNigra"]'
 groups_to_integrate: "All"
 
-# randomize merge order prior to integration 
-random_merge: true
+# randomize merge order prior to integration
+random_merge: '--random_merge'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,3 +23,6 @@ num_latent: 20
 # specify which projects to run through the workflow
 # to run a subset of projects use a python-formatted list '["1M_Immune_Cells", "HumanBrainSubstantiaNigra"]'
 groups_to_integrate: "All"
+
+# randomize merge order prior to integration 
+random_merge: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,4 +25,5 @@ num_latent: 20
 groups_to_integrate: "All"
 
 # randomize merge order prior to integration
-random_merge: '--random_merge'
+random_merge: '' # --random_merge
+fastmnn_auto_merge: '' # --fastmnn_auto_merge

--- a/scripts/02-prepare-merged-sce.R
+++ b/scripts/02-prepare-merged-sce.R
@@ -124,6 +124,12 @@ option_list <- list(
     type = "character",
     default = file.path(project_root, "results", "human_cell_atlas", "merged_sce"),
     help = "path to folder where all merged SCE objects files will be saved as RDS files"
+  ),
+  make_option(
+    opt_str = c("--seed"),
+    type = "integer",
+    default = NULL,
+    help = "random seed to set prior to merging"
   )
 )
 
@@ -131,6 +137,8 @@ option_list <- list(
 
 # Parse options
 opt <- parse_args(OptionParser(option_list = option_list))
+
+set.seed(opt$seed)
 
 # check that num genes provided is an integer
 if(!is.integer(opt$num_genes)){

--- a/scripts/02-prepare-merged-sce.R
+++ b/scripts/02-prepare-merged-sce.R
@@ -32,6 +32,7 @@
 # --num_hvg: Number of highly variable genes to select.
 #   Typically this is the output from running scpca-downstream-analyses
 # --merged_sce_dir: Path to folder where all merged SCE objects will be stored
+# --seed: Random seed to set prior to merging
 #
 
 # load the R project by finding the root directory using `here::here()`

--- a/scripts/02-prepare-merged-sce.R
+++ b/scripts/02-prepare-merged-sce.R
@@ -21,6 +21,8 @@
 #   Only required if --add_celltype is used.
 # --batch_column: The name of the column in colData that indicates the batches for each cell,
 #   typically this corresponds to the library id. Default is "batch".
+# --random_merge: Used to indicate whether or not to merge SCE objects in a random order. 
+#   Default is FALSE.
 # --subset_hvg: Indicates whether or not to subset the merged SCE object by highly variable genes.
 #   If --subset_hvg is used, the merged SCE object will only contain genes
 #   identified as highly variable genes.
@@ -66,8 +68,7 @@ option_list <- list(
     help = "Groups present in `grouping_var` column of metadata file to create merged SCE objects for.
       Default is 'All' which produces a merged object for each group in the metadata file. 
       Specify groups by using a vector, e.g. c('group1','group2')"
-  )
-  ,
+  ),
   make_option(
     opt_str = c("--add_celltype"),
     action = "store_true",
@@ -88,6 +89,12 @@ option_list <- list(
     default = "batch",
     help = "The name of the column in colData that indicates the batches for each cell,
       typically this corresponds to the library id. Default is 'batch'."
+  ),
+  make_option(
+    opt_str = c("--random_merge"),
+    default = FALSE,
+    action = "store_true",
+    help = "Used to indicate whether or not to merge SCE objects in a random order. Default is FALSE."
   ),
   make_option(
     opt_str = c("--subset_hvg"),
@@ -263,11 +270,12 @@ if(opt$add_celltype){
     purrr::map(create_grouped_sce_list, add_celltype = opt$add_celltype)
 }
 
-
 # create a list of merged SCE objects by group
 #  In this default usage, a batch column named `batch` will get created
 merged_sce_list <- grouped_sce_list %>%
-  purrr::map(combine_sce_objects, preserve_rowdata_columns = c("Gene", "gene_names", "ensembl_ids"))
+  purrr::map(combine_sce_objects, 
+             preserve_rowdata_columns = c("Gene", "gene_names", "ensembl_ids"),
+             random_merge = opt$random_merge)
 
 # HVG and dim reduction --------------------------------------------------------
 

--- a/scripts/03a-integrate-sce.R
+++ b/scripts/03a-integrate-sce.R
@@ -265,7 +265,7 @@ if (integration_method == "fastmnn") {
     auto.merge   = opt$fastmnn_auto_merge
   )
   
-  # add note about auto merge to 
+  # add note about auto merge to metadata of integrated object
   if(opt$fastmnn_auto_merge){
     auto_merge <- "auto"
   } else {

--- a/scripts/03a-integrate-sce.R
+++ b/scripts/03a-integrate-sce.R
@@ -27,6 +27,8 @@
 #   during integration instead of, by default, using only the previously-identified HVGs,
 #   stored in the `variable_genes` column of metadata slot. This argument is ignored if
 #   the provided method is not `fastMNN`.
+# --fastmnn_auto_merge: Indicates whether or not to use the auto.merge option for `fastMNN` integration.
+#   To perform auto.merge, use `--fastmnn_auto_merge`.
 # --seurat_reduction_method: Seurat reduction method to use, either `cca` or `rcpa`.
 #   This argument is ignored if the provided method is not `seurat`. There is no 
 #   default, so this argument is required if the provided method is `seurat`.
@@ -136,6 +138,13 @@ option_list <- list(
     default = FALSE,
     help = "Indicate whether to use all genes instead of only HVGs during `fastMNN` integration.
     To use all genes, use `--fastmnn_use_all_genes`"
+  ),
+  make_option(
+    opt_str = c("--fastmnn_auto_merge"),
+    action = "store_true",
+    default = FALSE,
+    help = "Indicates whether or not to use the auto.merge option for `fastMNN` integration.
+    To perform auto.merge, use `--fastmnn_auto_merge`."
   ),
   make_option(
     opt_str = c("--seurat_reduction_method"),
@@ -252,8 +261,19 @@ if (integration_method == "fastmnn") {
     batch_column = opt$batch_column,
     cosine_norm  = opt$fastmnn_no_cosine,
     gene_list    = fastmnn_gene_list,
-    seed         = opt$seed
+    seed         = opt$seed,
+    auto.merge   = opt$fastmnn_auto_merge
   )
+  
+  # add note about auto merge to 
+  if(opt$fastmnn_auto_merge){
+    auto_merge <- "auto"
+  } else {
+    auto_merge <- "input"
+  }
+  
+  metadata(integrated_sce_obj)$fastmnn_auto_merge <- auto_merge
+  
 }
 
 # Perform integration with harmony, if specified -------------------------

--- a/scripts/utils/integration-helpers.R
+++ b/scripts/utils/integration-helpers.R
@@ -98,6 +98,8 @@ find_input_sce_files <- function(library_ids, sce_dirs) {
 #' @param preserve_rowdata_columns An array of columns that appear in SCE rowData
 #'    which should not be renamed with the given library ID. For example,
 #'    such an array might be: `c("Gene", "ensembl_ids", "gene_names")`
+#' @param random_merge Used to indicate whether or not to merge SCE objects in a random order. 
+#'    Default is FALSE.
 #'
 #' @return The combined SCE object
 #'
@@ -105,7 +107,8 @@ find_input_sce_files <- function(library_ids, sce_dirs) {
 #' combine_sce_objects(sce_list, c("Gene", "ensembl_ids", "gene_names"))
 combine_sce_objects <- function(sce_list = list(),
                                 batch_column = "batch",
-                                preserve_rowdata_columns = NULL) {
+                                preserve_rowdata_columns = NULL,
+                                random_merge = FALSE) {
 
 
   # Ensure `sce_list` is named (according to library IDs) ----------------------
@@ -115,6 +118,14 @@ combine_sce_objects <- function(sce_list = list(),
   # Ensure `sce_list` has >=2 items --------------------------------------------
   if (length(sce_list) < 2) {
     stop("The `sce_list` must contain 2 or more SCE objects to combine.")
+  }
+  
+  # randomize order of SCE objects if specified
+  if(random_merge){
+    sce_list <- sample(sce_list)
+    merge_order <- "random"
+  } else {
+    merge_order <- "input"
   }
 
   # Ensure that colnames of colData match across all SCE objects ---------------
@@ -215,7 +226,9 @@ combine_sce_objects <- function(sce_list = list(),
   retain_pos <- which(names(colData(combined_sce)) %in% retain_cols)
   colData(combined_sce) <- colData(combined_sce)[, retain_pos]
 
-
+  # add a note in the metadata about merge order
+  metadata(combined_sce)$merge_order <- merge_order
+  
   # Return combined SCE object ----------------------------
   return(combined_sce)
 }


### PR DESCRIPTION
Closes #201 

This PR adds two new parameters to the integration workflow, one for specifying the merge order and one for specifying the integration order specifically for use with `fastmnn`. 

The first parameter, `--random_merge` that I added is a flag that can be used that will result in randomly shuffling the order of the SCE objects in the SCE list prior to creating the merged object. The merged object will be returned in the order that the SCE list was provided so using this flag results in a randomly ordered merged object. This object is then used as input into the integration scrips. Then for a tool like `fastmnn`, where the input order determines the integration order, unless otherwise specified, the randomized input that was used during merging will also be used for integration. Harmony does not have the option to specify the integration order and appears to use the order provided in the input object, so to ensure that the objects are all in the same order, I applied the randomization during the merge step rather than at the integration step. 

The second parameter, `--fastmnn_auto_merge` can be used only for integrating with `fastmnn` to test the use of `auto.merge=TRUE`. This means that objects will be integrated in an order that maximizes the number of mutual nearest neighbors between each pair rather than in the input order. This option is not applicable to other methods which is why I made it a `fastmnn` specific flag. Doing this means you can do both `--random_merge` and `--fastmnn_auto_merge` to compare random harmony vs. auto fastmnn or you can do `--ramdom_merge` only to compare the random input in both. To me this was the best way to accommodate the different ways both of these methods deal with integration order, but if others have other ideas I'm definitely open to that. 

In doing this, I also added notes to the metadata of the merged or integrated SCE objects to note the merge or integration order. Then in the integration report, I added messages that printed out what type of merging and integration was being used for that report. I attached an example of one of the reports for reference. 

For the snakefile, I added the new flags to the config file, but don't set them by default. When running the snakefile to test the new additions, I am running with the flags set and changing the results directory so as to separate results from when we don't enable random merge or auto integration. 
```
snakemake -c4 --use-conda --configfile config/config-scpca.yaml --config random_merge="--random_merge" fastmnn_auto_merge="--fastmnn_auto_merge" results_dir="results/scpca-random-auto" 
```

[SCPCP000007_integration_report.html.zip](https://github.com/AlexsLemonade/sc-data-integration/files/11020118/SCPCP000007_integration_report.html.zip)
